### PR TITLE
Fix electrification of line FR 311.

### DIFF
--- a/paths/fr/3/d0.osm
+++ b/paths/fr/3/d0.osm
@@ -122,6 +122,12 @@
   <node id='-60151204' action='modify' lat='48.93242515138' lon='2.01461654663' />
   <node id='-60151206' action='modify' lat='48.96128661965' lon='2.11349349976' />
   <node id='-60151208' action='modify' lat='48.91979300958' lon='2.20275741577' />
+  <node id='-60152937' action='modify' lat='50.41813278298' lon='1.65311495747'>
+    <tag k='name' v='ran' />
+  </node>
+  <node id='-60152954' action='modify' lat='49.89696006436' lon='2.28702892904'>
+    <tag k='name' v='sro' />
+  </node>
   <way id='-18682727' action='modify'>
     <nd ref='-60150601' />
     <nd ref='-60150578' />
@@ -226,6 +232,7 @@
   </way>
   <way id='-18682745' action='modify'>
     <nd ref='-60150614' />
+    <nd ref='-60152954' />
     <nd ref='-60150615' />
     <tag k='type' v='straight' />
   </way>
@@ -242,6 +249,7 @@
     <nd ref='-60150625' />
     <nd ref='-60150620' />
     <nd ref='-60150621' />
+    <nd ref='-60152937' />
     <nd ref='-60150624' />
     <nd ref='-60150623' />
     <nd ref='-60150622' />

--- a/rules/fr/3/d0.map
+++ b/rules/fr/3/d0.map
@@ -12,9 +12,11 @@ with detail = 0 {
     }
 
     with link = "line.fr.311" {
-        track(:first :double :cat:ac25 :pax,
-                path("d0.fr.311")[:lon.yb, :bou]
-        );
+    	let lb = path("d0.fr.311");
+
+        track(:first :double :cat:ac25 :pax, lb[:lon.yb, :sro]);
+	track(:first :double :pax, lb[:sro, :ran]);
+        track(:first :double :cat:ac25 :pax, lb[:ran, :bou]);
     }
 
     with link = "line.fr.314" {

--- a/rules/fr/3/d1/31.map
+++ b/rules/fr/3/d1/31.map
@@ -8,9 +8,11 @@ with detail = 1 {
     }
 
     with link = "line.fr.311" {
-        track(:first :double :cat:ac25 :pax,
-                path("d1.fr.311")[:lon.yb, :bou]
-        );
+    	let lb = path("d1.fr.311");
+
+        track(:first :double :cat:ac25 :pax, lb[:lon.yb, :sro]);
+	track(:first :double :pax, lb[:sro, :ran]);
+        track(:first :double :cat:ac25 :pax, lb[:ran, :bou]);
     }
 
     with link = "line.fr.312.300" {

--- a/rules/fr/3/d2/31.map
+++ b/rules/fr/3/d2/31.map
@@ -46,107 +46,128 @@ with detail = 2 {
 with detail = 2 {
     let lb = path("d2.fr.311");
 
-    with link = "line.fr.311" {
-        track(:first :double :cat:ac25 :pax, lb[:lon.yb, :abb]);
-        track(:first :double :cat:ac25 :pax, lb[:abb, :bou]);
+	with railway = :first :double :cat:ac25 :pax {
+    	with link = "line.fr.311" {
+			track(lb[:lon.yb, :ami.yl]);
+		}
 
-        guide(:linenum :cat:ac25 :pax,
-                lb[:ami + 12km] >> 1dt
-            --  lb[:ami + 12km] >> 3dt
-        );
-        label(:linenum :cat:ac25 :pax, lb[:ami + 12km] >> 3dt,
-            hbox(:center:bottom, "311")
-        );
-        guide(:linenum :cat:ac25 :pax,
-                lb[:abb - 7km] >> 1dt
-            --  lb[:abb - 7km] >> 3dt
-        );
-        label(:linenum :cat:ac25 :pax, lb[:abb - 7km] >> 3dt + (0.6dt, 0dt),
-            hbox(:center:bottom, "311")
-        );
-        line_badge(:cat:ac25 :pax, lb[:noy + 15km], "311");
-        guide(:linenum :cat:ac25 :pax,
-                lb[:eta + 11km] << 1dt
-            --  lb[:eta + 11km] << 3dt
-        );
-        label(:linenum :cat:ac25 :pax, lb[:eta + 11km] << 3dt,
-            hbox(:right:middle, "311 ")
-        );
-        guide(:linenum :cat:ac25 :pax,
-                lb[:hes + 2km] >> 1dt
-            --  lb[:hes + 2km] >> 3dt
-        );
-        label(:linenum :cat:ac25 :pax, lb[:hes + 2km] >> 3dt + (0dt, -0.6dt),
-            hbox(:left:middle, "311 ")
-        );
-    }
+		with link = "point.fr.Amiens" {
+			track(:station, lb[:ami.yl, :ami]);
+			statdot(lb[:ami]);
+			slabel(:right, lb[:ami] + (0dt, -1.5dt),
+				span(:bold, "Amiens")
+			);
+		}
 
-    with link = "point.fr.Amiens" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:ami]);
-        slabel(:right :cat:ac25 :pax, lb[:ami] + (0dt, -1.5dt),
-            span(:bold, "Amiens")
-        );
-    }
+    	with link = "line.fr.311" {
+			track(lb[:ami, :sro]);
+		}
 
-    with link = "point.fr.Saint-Roch" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:sro]);
-        slabel(:left :cat:ac25 :pax, lb[:sro] + (-1.7km, 0.5dt),
-            "Saint-Roch"
-        );
-    }
+		with link = "point.fr.Saint-Roch" {
+			statdot(lb[:sro]);
+			slabel(:left, lb[:sro] + (-1km, 0dt) + (-1dt, 0.5dt),
+				"Saint-Roch"
+			);
+		}
+	}
 
-    with link = "point.fr.Longpré-les-Corps-Saints" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:lon]);
-        slabel(:right :cat:ac25 :pax, lb[:lon] + (-1.5dt, -1.0dt),
-            vbox(:left:bottom, "Longpré-", " les-Corps-", "  Saints")
-        );
-    }
+	with railway = :first :double :pax {
+		with link = "line.fr.311" {
+			track(lb[:sro, :sro.yf]);
+			track(lb[:sro.yf, :lon.yc - 3.5km]);
+			line_label(:right:sw, lb[:sro.yf + 9.5km], "311");
 
-    with link = "point.fr.Abbeville" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:abb]);
-        slabel(:left :cat:ac25 :pax, lb[:abb] + (-1.8dt, 1.3dt),
-            "Abbeville"
-        );
-    }
+			with layer = -1 track(lb[:lon.yc - 3.5km, :lon.yc - 1.5km]);
+			track(lb[:lon.yc - 1.5km, :lon.yc]);
+		}
 
-    with link = "point.fr.Noyelles-sur-Mer" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:noy]);
-        slabel(:right :cat:ac25 :pax, lb[:noy] + (1.8dt, 1.0dt),
-            "Noyelles-sur-Mer"
-        );
-    }
+		with link = "point.fr.Longpré-les-Corps-Saints" {
+			track(:station, lb[:lon.yc, :lon]);
+			statdot(lb[:lon]);
+			slabel(:right, lb[:lon] + (-1.5dt, -1.0dt),
+				vbox(:left:bottom, "Longpré-", " les-Corps-", "  Saints")
+			);
+		}
 
-    with link = "point.fr.Rang-du-Fliers-Verton" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:ran]);
-        slabel(:left :cat:ac25 :pax, lb[:ran] + (-1.8dt, 1.0dt),
-            "Rang-du-Fliers-Verton"
-        );
-    }
+		with link = "line.fr.311" {
+			track(lb[:lon, :abb.yp]);
+			line_label(:right:sw, lb[:abb.yp - 7.8km], "311");
+		}
 
-    with link = "point.fr.Étaples-Le-Touquet" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:eta]);
-        slabel(:left :cat:ac25 :pax, lb[:eta] + (-1.8dt, 2.3dt),
-            "Étaples-Le-Touquet"
-        );
-    }
+		with link = "point.fr.Abbeville" {
+			track(:station, lb[:abb.yp, :abb.ye]);
+			statdot(lb[:abb]);
+			slabel(:left, lb[:abb] + (-1.6dt, 1.4dt), "Abbeville");
+		}
 
-    with link = "point.fr.Hesdigneul" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:hes]);
-        slabel(:left :cat:ac25 :pax, lb[:hes] + (-1.8dt, 2.3dt),
-            "Hesdigneul"
-        );
-    }
+		with link = "line.fr.311" {
+			track(lb[:abb.ye, :noy]);
+		}
 
-    with link = "point.fr.Outreau" {
-        with layer = 1 marker(:statdot :cat:ac25, lb[:out]);
-    }
+		with link = "point.fr.Noyelles-sur-Mer" {
+			track(:station, lb[:noy, :noy.yv]);
+			statdot(lb[:noy]);
+			slabel(:right, lb[:noy] + (1.7dt, 1.0dt), "Noyelles-sur-Mer");
+		}
 
-    with link = "point.fr.Boulogne-Ville" {
-        with layer = 1 marker(:statdot :cat:ac25 :pax, lb[:bou]);
-        slabel(:right :cat:ac25 :pax, lb[:bou] + (1.8dt, 1.5dt),
-            span(:bold, "Boulogne")
-        );
-    }
+		with link = "line.fr.311" {
+			track(lb[:noy.yv, :ran]);
+			line_label(:right:w, lb[:noy + 15km], "311");
+		}
+	}
+
+	with railway = :first :double :cat:ac25 :pax {
+		with link = "point.fr.Rang-du-Fliers-Verton" {
+			statdot(lb[:ran]);
+			slabel(:left, lb[:ran] + (-1.8dt, 1.0dt),
+				"Rang-du-Fliers-Verton"
+			);
+		}
+
+		with link = "line.fr.311" {
+			track(lb[:ran, :eta.ys]);
+			line_label(:left:e, lb[:ran + 5.5km], "311");
+		}
+
+		with link = "point.fr.Étaples-Le-Touquet" {
+			track(:station, lb[:eta.ys, :eta]);
+			statdot(lb[:eta]);
+			slabel(:left, lb[:eta] + (-1.8dt, 2.3dt), "Étaples-Le-Touquet");
+		}
+
+		with link = "line.fr.311" {
+			track(lb[:eta, :hes.yo]);
+			line_label(:left:e, lb[:eta + 8km], "311");
+		}
+
+		with link = "point.fr.Hesdigneul" {
+			track(:station, lb[:hes.yo, :hes]);
+			statdot(lb[:hes]);
+			slabel(:left, lb[:hes] + (-1.8dt, 2.3dt), "Hesdigneul");
+		}
+
+		with link = "line.fr.311" {
+			track(lb[:hes, :out]);
+			line_label(:right:sw, lb[:hes + 2.2km], "311");
+		}
+
+		with link = "point.fr.Outreau" {
+			track(:station, lb[:out, :out.ym]);
+			statdot(:nopax, lb[:out]);
+			slabel(:left :nopax, lb[:out] + (-1.8dt, 1.0dt), "Outreau");
+		}
+
+		with link = "line.fr.311" {
+			track(lb[:out.ym, :bou]);
+		}
+
+		with link = "point.fr.Boulogne-Ville" {
+			statdot(lb[:bou]);
+			slabel(:right, lb[:bou] + (1.7dt, 1.0dt),
+				span(:bold, "Boulogne")
+			);
+		}
+	}
 }
 
 

--- a/rules/fr/3/d2/32.map
+++ b/rules/fr/3/d2/32.map
@@ -115,7 +115,8 @@ with detail = 2 {
 
     with link = "line.fr.322" {
         track(:first :removed, cl[:can.yl, :sle]);
-        track(:first :closed, cl[:sle, :lon.yc]);
+        track(:first :closed, cl[:sle, :lon.yc - 3.5dt]);
+        track(:first :closed :casing, cl[:lon.yc - 3.5dt, :lon.yc]);
         track(:first :removed, cl[:lon.yl, :lor.yl]);
 
         guide(:linenum :closed,


### PR DESCRIPTION
This PR fixes the electrification of line FR 311 which is missing between St-Roch and Rang-du-Fliers-Verton.

While at it, it also brings the line to current standards.

Fixes #25.